### PR TITLE
New optional settings: Limit Shop Item Prices and List of Containers that can be used as Shops

### DIFF
--- a/Contents/mods/pz-shops/media/lua/client/shop-containerLockOut.lua
+++ b/Contents/mods/pz-shops/media/lua/client/shop-containerLockOut.lua
@@ -121,7 +121,7 @@ end
 
 
 local function shopStore(container, player)
-    if not container or not player then return end
+    if not _internal.isValidContainer(container) or not player then return end
     local object = container:getParent()
     local objStoreID = object:getModData().storeObjID
     if objStoreID then
@@ -159,7 +159,7 @@ local function hideButtons(UI, STEP)
 
                     containerButton.onclick = ISInventoryPage.onShopClick
                     containerButton.onRightMouseDown = ISInventoryPage.onShopRightMouseDown
-                    
+
                     if not canView then
                         containerButton:setOnMouseOverFunction(nil)
                         containerButton:setOnMouseOutFunction(nil)

--- a/Contents/mods/pz-shops/media/lua/client/shop-contextMenu.lua
+++ b/Contents/mods/pz-shops/media/lua/client/shop-contextMenu.lua
@@ -83,7 +83,7 @@ function CONTEXT_HANDLER.generateContextMenu(playerID, context, worldObjects, te
 
                 elseif worldObject:getModData().storeObjID then
                     contextText = getText("ContextMenu_SHOP_AT").." "..objectName
-                    
+
                 elseif _internal.isAdminHostDebug() then
                     contextText = objectName.." [ "..getText("ContextMenu_ASSIGN_STORE").." ]"
                 end

--- a/Contents/mods/pz-shops/media/lua/client/shop-window.lua
+++ b/Contents/mods/pz-shops/media/lua/client/shop-window.lua
@@ -537,7 +537,7 @@ function storeWindow:initialise()
     self.assignComboBox:instantiate()
     self:addChild(self.assignComboBox)
     self:populateComboList()
-    
+
     local acb = self.assignComboBox
 
     self.aBtnDel = ISButton:new(acb.x-delBtnW-2, acb.y, delBtnW, acb.height, getText("IGUI_DELETEPRESET"), self, storeWindow.onClick)
@@ -911,7 +911,7 @@ function storeWindow:update()
         self:closeStoreWindow()
         return
     end
-    
+
     if activityExpired or not self.player or not self.worldObject or (math.abs(self.player:getX()-self.worldObject:getX())>2) or (math.abs(self.player:getY()-self.worldObject:getY())>2) then
         self:closeStoreWindow()
         return
@@ -1526,7 +1526,13 @@ function storeWindow:onClick(button)
         end
 
         local price = 0
-        if self.addStockPrice.enable and self.addStockPrice:getInternalText() then price = tonumber(self.addStockPrice:getInternalText()) end
+        if self.addStockPrice.enable and self.addStockPrice:getInternalText() then
+            price = tonumber(self.addStockPrice:getInternalText())
+
+            if SandboxVars.ShopsAndTraders.ShopItemPriceLimit > 0 and price > SandboxVars.ShopsAndTraders.ShopItemPriceLimit then
+                price = SandboxVars.ShopsAndTraders.ShopItemPriceLimit
+            end
+        end
 
         local quantity = 0
         if self.addStockQuantity.enable and self.addStockQuantity:getInternalText() then quantity = tonumber(self.addStockQuantity:getInternalText()) end
@@ -1575,7 +1581,7 @@ function storeWindow:onClick(button)
         reader:close()
 
         local totalStr = table.concat(lines, "\n")
-        
+
         local tbl = _internal.stringToTable(totalStr)
         if (not tbl) or (type(tbl)~="table") then
             print("ERROR: STORES MASS IMPORT FAILED.")

--- a/Contents/mods/pz-shops/media/lua/client/shop-window.lua
+++ b/Contents/mods/pz-shops/media/lua/client/shop-window.lua
@@ -18,7 +18,7 @@ function storeWindow:getItemTypesInStoreContainer(itemType)
     if not worldObject then return end
 
     local container = worldObject:getContainer()
-    if not container then return end
+    if not _internal.isValidContainer(container) then return end
 
     local items = container:getAllType(itemType)
     if items then return items end

--- a/Contents/mods/pz-shops/media/lua/shared/Translate/EN/Sandbox_EN.txt
+++ b/Contents/mods/pz-shops/media/lua/shared/Translate/EN/Sandbox_EN.txt
@@ -44,6 +44,9 @@ Sandbox_EN = {
     Sandbox_ShopsAndTraders_ActivityTimeOut_tooltip = "Set to 0 to disable. Timer is counted in seconds."
 
     Sandbox_ShopsAndTraders_ShopItemPriceLimit = "Price Limit On Shop Items",
-    Sandbox_ShopsAndTraders_ShopItemPriceLimit_tooltip = "The maximum price a shop item can assume.\nDefault to 0.00 shop items will not have a limit on their price",
+    Sandbox_ShopsAndTraders_ShopItemPriceLimit_tooltip = "The maximum price a shop item can assume.\nDefault to 0.00 shop items will not have a limit on their price,",
+
+    Sandbox_ShopsAndTraders_ShopContainers = "Containers that can be used as Shops",
+    Sandbox_ShopsAndTraders_ShopContainers_tooltip = "A comma separated list of the container names that can be used as shops (e.g. Crate,Military Crate).\nBy default if left blank, all containers can be used as shops.",
 
 	}

--- a/Contents/mods/pz-shops/media/lua/shared/Translate/EN/Sandbox_EN.txt
+++ b/Contents/mods/pz-shops/media/lua/shared/Translate/EN/Sandbox_EN.txt
@@ -43,4 +43,7 @@ Sandbox_EN = {
 	Sandbox_ShopsAndTraders_ActivityTimeOut = "Shopping Activity Time Out"
     Sandbox_ShopsAndTraders_ActivityTimeOut_tooltip = "Set to 0 to disable. Timer is counted in seconds."
 
+    Sandbox_ShopsAndTraders_ShopItemPriceLimit = "Price Limit On Shop Items",
+    Sandbox_ShopsAndTraders_ShopItemPriceLimit_tooltip = "The maximum price a shop item can assume.\nDefault to 0.00 shop items will not have a limit on their price",
+
 	}

--- a/Contents/mods/pz-shops/media/lua/shared/shop-recipe.lua
+++ b/Contents/mods/pz-shops/media/lua/shared/shop-recipe.lua
@@ -31,7 +31,7 @@ function shopsAndTradersRecipe.checkDeedValid(recipe, playerObj, item) --onCanPe
     if not item then return false end
 
     local cont = item:getContainer()
-    if not cont then return false end
+    if not _internal.isValidContainer(cont) then return false end
 
     local worldObj = cont and (not cont:isInCharacterInventory(playerObj)) and cont:getParent()
     if not worldObj then return false end
@@ -46,7 +46,7 @@ function shopsAndTradersRecipe.onActivateDeed(items, result, player) --onCreate
 
     local item = items:get(0)
     local cont = item:getContainer()
-    if not cont then return false end
+    if not _internal.isValidContainer(cont) then return false end
 
     local worldObj = cont and (not cont:isInCharacterInventory(player)) and cont:getParent()
     if not worldObj then return false end

--- a/Contents/mods/pz-shops/media/lua/shared/shop-shared.lua
+++ b/Contents/mods/pz-shops/media/lua/shared/shop-shared.lua
@@ -105,9 +105,23 @@ end
 
 ---@param container ItemContainer
 function _internal.isValidContainer(container)
-    if not container return false
+    if not container then
+        return false
+    end
 
-    return true
+    local shopContainers = SandboxVars.ShopsAndTraders.ShopContainers
+    if shopContainers == "" then
+        return true
+    end
+
+    local containerName = _internal.getWorldObjectName(container:getParent())
+    for shopContainer in string.gmatch(shopContainers, "([^,]+)") do
+        if containerName == shopContainer then
+            return true
+        end
+    end
+
+    return false
 end
 
 return _internal

--- a/Contents/mods/pz-shops/media/lua/shared/shop-shared.lua
+++ b/Contents/mods/pz-shops/media/lua/shared/shop-shared.lua
@@ -103,4 +103,11 @@ function _internal.stringToTable(inputstr)
     return tblTbl
 end
 
+---@param container ItemContainer
+function _internal.isValidContainer(container)
+    if not container return false
+
+    return true
+end
+
 return _internal

--- a/Contents/mods/pz-shops/media/sandbox-options.txt
+++ b/Contents/mods/pz-shops/media/sandbox-options.txt
@@ -38,3 +38,6 @@ option ShopsAndTraders.MaxUsers
 
 option ShopsAndTraders.ActivityTimeOut
 {type = integer, min = 0, max = 3600, default = 0, page = ShopsAndTraders, translation = ShopsAndTraders_ActivityTimeOut,}
+
+option ShopsAndTraders.ShopItemPriceLimit
+{type = double, min = 0.00, max = 999999999, default = 0.00, page = ShopsAndTraders, translation = ShopsAndTraders_ShopItemPriceLimit,}

--- a/Contents/mods/pz-shops/media/sandbox-options.txt
+++ b/Contents/mods/pz-shops/media/sandbox-options.txt
@@ -41,3 +41,6 @@ option ShopsAndTraders.ActivityTimeOut
 
 option ShopsAndTraders.ShopItemPriceLimit
 {type = double, min = 0.00, max = 999999999, default = 0.00, page = ShopsAndTraders, translation = ShopsAndTraders_ShopItemPriceLimit,}
+
+option ShopsAndTraders.ShopContainers
+{type = string, default = , page = ShopsAndTraders, translation = ShopsAndTraders_ShopContainers,}

--- a/Contents/mods/pz-shops/media/sandbox-options.txt
+++ b/Contents/mods/pz-shops/media/sandbox-options.txt
@@ -13,7 +13,7 @@ option ShopsAndTraders.ShopsUseCash
 {type = enum, numValues = 3, default = 1, page = ShopsAndTraders, translation = ShopsAndTraders_ShopsUseCash, valueTranslation = ShopsAndTraders_CashPolicy,}
 
 option ShopsAndTraders.StartingWallet
-{type = double, min = 0.01, max = 1000000, default = 25, page = ShopsAndTraders, translation = ShopsAndTraders_StartingWallet,}
+{type = double, min = 0.00, max = 1000000, default = 25, page = ShopsAndTraders, translation = ShopsAndTraders_StartingWallet,}
 
 option ShopsAndTraders.MoneyWeight
 {type = double, min = 0.001, max = 1000, default = 0.001, page = ShopsAndTraders, translation = ShopsAndTraders_MoneyWeight,}


### PR DESCRIPTION
This PR adds two new features to _Shops And Trades_ mod:

- Possibility to set a limit for the shop items price
- Possibility to allow only a certain list of containers that can be used as shops
- **Extra:** Allow Starting Amount of Money to be set to 0 (zero)

## Possibility to set a limit for the shop items price

When the `ShopItemPriceLimit` sandbox option is set to a value greater than 0, the price for all items that players wish to add to their shops will be limited to that amount.

The reason behind this feature is to prevent players from using their shops as exploits to have a safe place to store their items (e.g. adding all their valuables into their shop at an unreasonable price so that it is impossible for other players get them). Additionally, this can be an interesting feature for servers where it is important to keep things in balance with the server's trading and currency system.

![image](https://github.com/Chuckleberry-Finn/pz-shops/assets/163025524/ed664e21-3c7d-401c-a560-0a2b0e5d2fe6)

## Possibility to allow only a certain list of containers that can be used as shops

The `ShopContainers` sandbox option can be used to allow only certain types of containers to be used as a shop. If set, it should contain a comma-separated list of container names (e.g. "Crate,Military Crate") that can be used as shops. If left empty, all containers can be used as shops.

The reason for this feature is for servers where it is important to limit the type of containers that can be used as shops, for example to only allow small containers with a limited capacity, OR to be able to use custom sprites (created via custom recipes) more easy to recognize as shops on the world map.

![image](https://github.com/Chuckleberry-Finn/pz-shops/assets/163025524/e8c747d7-4a0b-425f-acfd-b8a90c0b54ff)

## **Extra:** Allow Starting Amount of Money to be set to 0 (zero)

This is a small change, the sandbox option `StartingWallet` can now assume a minimum value of `0.00` so to allow servers to let new players to start with no money in their wallet.

![image](https://github.com/Chuckleberry-Finn/pz-shops/assets/163025524/4a949541-3d61-4109-b284-0d4107e99cc4)